### PR TITLE
feat(#37): 커뮤니티 페이지 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,31 @@
+import { useLocation } from 'react-router-dom';
 import Router from './routes/Router';
+import NavBar from './components/NavBar';
 
 const App = () => {
+  const location = useLocation();
+  const hideNavPaths = [
+    '/select-login',
+    '/consultant-chatbot',
+    '/login',
+    '/signup',
+    '/notification',
+    '/mypage',
+    '/password',
+    '/buy',
+    '/myheart',
+    '/mypage',
+    '/counselor-chatbot'
+  ]; // 네비바 숨길 경로 추가
+
   return (
-    <div className="app-container">
-      <Router></Router>
-    </div>
+    <>
+      {!hideNavPaths.includes(location.pathname) && <NavBar />}
+
+      <div className="app-container">
+        <Router></Router>
+      </div>
+    </>
   );
 };
 

--- a/src/components/BackHeader.tsx
+++ b/src/components/BackHeader.tsx
@@ -30,7 +30,7 @@ const Wrapper = styled.div`
 
 const HeaderContainer = styled.header`
   width: 100%;
-  max-width: 425px;
+  max-width: 450px;
   height: 64px;
   display: flex;
   align-items: center;

--- a/src/components/CloseHeader.tsx
+++ b/src/components/CloseHeader.tsx
@@ -37,7 +37,7 @@ const HeaderContainer = styled.header`
   z-index: 1000;
 
   width: 100%;
-  max-width: 425px;
+  max-width: 450px;
   height: 64px;
   display: flex;
   align-items: center;

--- a/src/components/CommunityCard.tsx
+++ b/src/components/CommunityCard.tsx
@@ -1,34 +1,54 @@
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 interface CommunityCardProps {
+  postId: number;
   title: string;
   content: string;
   username: string;
   date: Date;
   likes: number;
   comments: number;
+  src?: string;
 }
 
 const CommunityCard = ({
+  postId,
   title,
   content,
   username,
   date,
   likes,
-  comments
+  comments,
+  src
 }: CommunityCardProps) => {
+  const navigate = useNavigate();
   const formattedDate = date.toISOString().split('T')[0].replace(/-/g, '.');
 
+  const handleCardClick = () => {
+    navigate('/community/detail', { state: { postId } });
+  };
+
   return (
-    <CardContainer>
-      <ContentWrapper>
-        <Title>{title}</Title>
-        <Content>{content}</Content>
-        <InfoContainer>
-          <Username>{username}</Username>
-          <Date>{formattedDate}</Date>
-        </InfoContainer>
-      </ContentWrapper>
+    <CardContainer onClick={handleCardClick}>
+      {/* 커뮤니티 내용 */}
+      <ImageContentWrapper>
+        <ContentWrapper>
+          <Title>{title}</Title>
+          <Content>{content}</Content>
+          <InfoContainer>
+            <Username>{username}</Username>
+            <Date>{formattedDate}</Date>
+          </InfoContainer>
+        </ContentWrapper>
+        {src && (
+          <Image>
+            <img src={src} alt="Image" />
+          </Image>
+        )}
+      </ImageContentWrapper>
+
+      {/* 좋아요와 댓글 */}
       <StatBoxContainer>
         <StatBox>
           <img src="/icons/likes.svg" alt="Likes" />
@@ -69,6 +89,34 @@ const CardContainer = styled.div`
   }
 `;
 
+const ImageContentWrapper = styled.div`
+  display: flex;
+  gap: 20px;
+`;
+
+const ContentWrapper = styled.div`
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 6px;
+`;
+
+const Image = styled.div`
+  width: 72px;
+  height: 72px;
+  border-radius: 8px;
+  overflow: hidden;
+  flex-shrink: 0;
+
+  img {
+    width: 100%;
+    height: 100%;
+    display: block;
+    object-fit: cover;
+  }
+`;
+
 const InfoContainer = styled.div`
   display: flex;
   margin-top: 2px;
@@ -80,14 +128,6 @@ const InfoContainer = styled.div`
   }
 `;
 
-const ContentWrapper = styled.div`
-  flex-grow: 1;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  gap: 6px;
-`;
-
 const StatBoxContainer = styled.div`
   display: flex;
 `;
@@ -96,6 +136,12 @@ const Title = styled.p`
   color: var(--gr30);
   font-weight: 600;
   font-size: 18px;
+  display: -webkit-box; /* Flexbox 기반 레이아웃을 사용 */
+  -webkit-line-clamp: 1; /* 최대 1줄까지만 표시 */
+  -webkit-box-orient: vertical; /* 박스 방향을 세로로 설정 */
+  overflow: hidden; /* 넘치는 텍스트 숨김 */
+  text-overflow: ellipsis;
+  white-space: normal;
 `;
 
 const Content = styled.p`

--- a/src/components/CommunityTab.tsx
+++ b/src/components/CommunityTab.tsx
@@ -21,11 +21,15 @@ const CommunityTab = ({ activeTab, setActiveTab }: CommunityTabProps) => {
 };
 
 const TabContainer = styled.div`
+  position: fixed;
+  z-index: 1000;
+  top: 64px;
   width: 100%;
   height: 28px;
   padding: 0 20px;
   border-bottom: 0.5px solid var(--gr80);
   display: flex;
+  background-color: var(--gr100);
 `;
 
 interface TabProps {

--- a/src/components/CommunityTab.tsx
+++ b/src/components/CommunityTab.tsx
@@ -42,7 +42,7 @@ const Tab = styled.div<TabProps>`
   flex-direction: column;
   justify-content: space-between;
   align-items: center;
-  padding-top: 10px;
+  padding-top: 8px;
 
   span {
     font-size: 16px;

--- a/src/components/CommunityTab.tsx
+++ b/src/components/CommunityTab.tsx
@@ -25,7 +25,7 @@ const TabContainer = styled.div`
   z-index: 1000;
   top: 64px;
   width: 100%;
-  height: 28px;
+  height: 40px;
   padding: 0 20px;
   border-bottom: 0.5px solid var(--gr80);
   display: flex;
@@ -42,6 +42,7 @@ const Tab = styled.div<TabProps>`
   flex-direction: column;
   justify-content: space-between;
   align-items: center;
+  padding-top: 10px;
 
   span {
     font-size: 16px;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -17,7 +17,7 @@ const Header = ({
   title,
   showDropdownIcon = true,
   showSearchIcon = true,
-  showNotificationIcon = true,
+  showNotificationIcon = true
 }: HeaderProps) => {
   const navigate = useNavigate();
   const [isDropdownOpen, setDropdownOpen] = useState(false);
@@ -65,7 +65,7 @@ const Header = ({
 
 const HeaderContainer = styled.header`
   width: 100%;
-  max-width: 425px;
+  max-width: 450px;
   height: 64px;
   display: flex;
   align-items: center;

--- a/src/components/HomeHeader.tsx
+++ b/src/components/HomeHeader.tsx
@@ -41,7 +41,7 @@ const HeaderContainer = styled.header`
   z-index: 1000;
 
   width: 100%;
-  max-width: 425px;
+  max-width: 450px;
   height: 64px;
   display: flex;
   align-items: center;

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -78,7 +78,7 @@ const NavContainer = styled.div`
 
 const Nav = styled.nav`
   width: 100%;
-  max-width: 375px;
+  max-width: 450px;
   height: 52px;
   display: flex;
   align-items: center;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,41 +2,15 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { Provider } from 'react-redux';
 import { store } from './store/store.ts';
-import { BrowserRouter, useLocation } from 'react-router-dom';
+import { BrowserRouter } from 'react-router-dom';
 import './index.css';
 import App from './App.tsx';
-import NavBar from './components/NavBar.tsx';
-
-const Root = () => {
-  const location = useLocation();
-  const hideNavPaths = [
-    '/select-login',
-    '/consultant-chatbot',
-    '/login',
-    '/signup',
-    '/notification',
-    '/mypage',
-    '/password',
-    '/buy',
-    '/myheart',
-    '/mypage',
-    '/counselor-chatbot'
-  ]; // 네비바 숨길 경로 추가
-
-  return (
-    <>
-      {!hideNavPaths.includes(location.pathname) && <NavBar />}
-
-      <App />
-    </>
-  );
-};
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <Provider store={store}>
       <BrowserRouter>
-        <Root />
+        <App />
       </BrowserRouter>
     </Provider>
   </StrictMode>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -20,12 +20,13 @@ const Root = () => {
     '/buy',
     '/myheart',
     '/mypage',
-    '/counselor-chatbot',
+    '/counselor-chatbot'
   ]; // 네비바 숨길 경로 추가
 
   return (
     <>
       {!hideNavPaths.includes(location.pathname) && <NavBar />}
+
       <App />
     </>
   );

--- a/src/pages/Community.tsx
+++ b/src/pages/Community.tsx
@@ -10,19 +10,173 @@ const Community = () => {
     <>
       <Header title="커뮤니티" showDropdownIcon={false} />
 
-      <main className="content">
+      <main className="content pt-7">
         <CommunityTab activeTab={activeTab} setActiveTab={setActiveTab} />
-        <CommunityCard
-          title="파혼할까 고민 중입니다."
-          content="안녕하세요. 이런 글을 올리게 될 줄은 몰랐는데, 요즘 정말 고민이 많아져서 여러분의 조언을 듣고 싶습니다. 결혼 준비를 하면서 생각하지도 못했던 문제들이 하나둘씩 쌓이기 시작했어요. 어떡하면 좋을까요?"
-          username="행복한 신부"
-          date={new Date('2024-09-12')}
-          likes={30}
-          comments={10}
-        />
+        {activeTab === 0 &&
+          lifeData.map(
+            ({
+              postId,
+              title,
+              content,
+              username,
+              date,
+              likes,
+              comments,
+              src
+            }) => (
+              <CommunityCard
+                key={postId}
+                postId={postId}
+                title={title}
+                content={content}
+                username={username}
+                date={date}
+                likes={likes}
+                comments={comments}
+                src={src}
+              />
+            )
+          )}
+        {activeTab === 1 &&
+          tipData.map(
+            (
+              { postId, title, content, username, date, likes, comments, src },
+              index
+            ) => (
+              <CommunityCard
+                key={index}
+                postId={postId}
+                title={title}
+                content={content}
+                username={username}
+                date={date}
+                likes={likes}
+                comments={comments}
+                src={src}
+              />
+            )
+          )}
       </main>
     </>
   );
 };
+
+interface CommunityData {
+  postId: number;
+  title: string;
+  content: string;
+  username: string;
+  date: Date;
+  likes: number;
+  comments: number;
+  src?: string;
+}
+
+const lifeData: CommunityData[] = [
+  {
+    postId: 0,
+    title: '파혼할까 고민 중입니다',
+    content:
+      '안녕하세요. 이런 글을 올리게 될 줄은 몰랐는데, 요즘 정말 고민이 많아져서 여러분의 조언을 듣고 싶습니다. 결혼 준비를 하면서 생각하지도 못했던 문제들이 하나둘씩 쌓이기 시작했어요. 어떡하면 좋을까요?',
+    username: '행복한 신부',
+    date: new Date('2024-11-06'),
+    likes: 30,
+    comments: 10
+  },
+  {
+    postId: 1,
+    title: '다들 청첩장 어디서 하셨나요?',
+    content:
+      '저희 결혼 준비가 한창인데요, 청첩장 제작을 어디서 해야 할지 고민이 많아서요. 예산도 적당히 맞추면서도 예쁘고 고급스러운 청첩장을 만들고 싶은데, 추천해주실 만한 업체나 온라인 사이트 있을까요?',
+    username: '웨딩피치 신부',
+    date: new Date('2024-10-31'),
+    likes: 2,
+    comments: 13,
+    src: '/images/card-banner-bg.png'
+  },
+  {
+    postId: 2,
+    title: '결혼 준비 스트레스',
+    content: '결혼 준비가 생각보다 힘드네요.',
+    username: '힘든 예비신랑',
+    date: new Date('2024-10-15'),
+    likes: 21,
+    comments: 0
+  },
+  {
+    postId: 3,
+    title: '결혼식 축가 추천 부탁드립니다. 제목이 긴 예시입니다.',
+    content:
+      '결혼식에서 부를 축가를 아직 못 정했어요. 감동적이면서도 분위기를 살릴 수 있는 곡 추천해주시면 감사하겠습니다!',
+    username: '음악 좋아하는 신랑',
+    date: new Date('2024-10-14'),
+    likes: 0,
+    comments: 2
+  },
+  {
+    postId: 4,
+    title: '드디어 결혼까지 20일이 남았네요',
+    content:
+      '안녕하세요. 드디어 결혼식이 20일 앞으로 다가왔어요! 정말 꿈만 같은 기분이에요. 준비하면서 힘든 일도 많았지만, 이제 곧 평생 함께할 사람과 새로운 시작을 한다고 생각하니 설레고 기대되네요!',
+    username: '드디어 장가간다',
+    date: new Date('2024-08-28'),
+    likes: 12,
+    comments: 0,
+    src: '/images/card-banner-bg.png'
+  }
+];
+
+const tipData: CommunityData[] = [
+  {
+    postId: 0,
+    title: '매일 밤, 잠 못드시나요?',
+    content:
+      '하루의 시작을 알리는 안부처럼 건네는 한마디죠. 그만큼 수면의 질은 우리의 삶에 중요한 요소랍니다. 반면 한국인의 평균 수면은 6.9시간으로 꽤 짧은 시간이라네요.',
+    username: '홍길동 상담사',
+    date: new Date('2024-11-05'),
+    likes: 18,
+    comments: 5,
+    src: '/images/card-banner-bg.png'
+  },
+  {
+    postId: 1,
+    title: '스트레스를 줄이는 간단한 방법!',
+    content: '깊게 숨을 들이마시고 천천히 내쉬는 호흡법을 시도해보세요.',
+    username: '홍길순 상담사',
+    date: new Date('2024-10-25'),
+    likes: 12,
+    comments: 3,
+    src: '/images/card-banner-bg.png'
+  },
+  {
+    postId: 2,
+    title: '집중하기 힘든 나, 혹시 성인 ADHD인가요?',
+    content: '매일 아침 물 한 잔으로 뇌를 깨워보세요.',
+    username: '박영희 상담사',
+    date: new Date('2024-10-20'),
+    likes: 25,
+    comments: 8
+  },
+  {
+    postId: 3,
+    title: '불면증에 좋은 차 추천',
+    content: '카모마일 차를 마시면 편안한 수면에 도움이 됩니다.',
+    username: '김철수 상담사',
+    date: new Date('2024-10-18'),
+    likes: 25,
+    comments: 8
+  },
+  {
+    postId: 4,
+    title: '효율적인 시간 관리 방법, 이렇게 해보세요!',
+    content:
+      '시간 관리는 현대인에게 필수적인 스킬입니다. 우선 하루를 시작하기 전에 그 날 해야 할 일을 목록으로 정리해보세요.',
+    username: '박영희 상담사',
+    date: new Date('2024-10-20'),
+    likes: 25,
+    comments: 8,
+    src: '/images/card-banner-bg.png'
+  }
+];
 
 export default Community;

--- a/src/pages/Community.tsx
+++ b/src/pages/Community.tsx
@@ -10,7 +10,7 @@ const Community = () => {
     <>
       <Header title="커뮤니티" showDropdownIcon={false} />
 
-      <main className="content pt-7">
+      <main className="content pt-10">
         <CommunityTab activeTab={activeTab} setActiveTab={setActiveTab} />
         {activeTab === 0 &&
           lifeData.map(

--- a/src/pages/CommunityDetail.tsx
+++ b/src/pages/CommunityDetail.tsx
@@ -1,0 +1,18 @@
+import BackHeader from '@/components/BackHeader';
+import { useLocation } from 'react-router-dom';
+
+const CommunityDetail = () => {
+  const location = useLocation();
+  const { postId } = location.state || {};
+
+  return (
+    <>
+      <BackHeader title="" />
+      <main className="content">
+        <h1>{postId} 게시물 상세 페이지</h1>
+      </main>
+    </>
+  );
+};
+
+export default CommunityDetail;

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -15,6 +15,7 @@ import CounselorChatBot from '@/pages/CounselorChatBot.tsx';
 import UserGuide from '@/pages/UserGuide.tsx';
 import Buy from '@/pages/Buy.tsx';
 import MyHeart from '@/pages/MyHeart.tsx';
+import CommunityDetail from '@/pages/CommunityDetail.tsx';
 
 function Router() {
   return (
@@ -35,6 +36,7 @@ function Router() {
       <Route path="/user-guide" element={<UserGuide />} />
       <Route path="/buy" element={<Buy />} />
       <Route path="/myheart" element={<MyHeart />} />
+      <Route path="/community/detail" element={<CommunityDetail />} />
       {/* 추가 라우트 */}
     </Routes>
   );


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#51 #52 

## 📝 작업 내용

- 가상 커뮤니티 데이터 생성
- 이미지 들어간 커뮤니티 카드 컴포넌트 구현
- 커뮤니티 탭 연동
- 게시글 상세 페이지 갔다 온 후 기존 스크롤 적용 기능 구현

## 📸 스크린샷

![image](https://github.com/user-attachments/assets/573340b3-c443-419b-9a00-03aab87e6d18)
![image](https://github.com/user-attachments/assets/50befbd0-999f-461b-a2c3-6bc343ca41a3)

## 💬 리뷰 요구사항
